### PR TITLE
add bindingPort option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ var udp = require('datagram-stream');
 var stream = udp({
     address     : '0.0.0.0'   //address to bind to
     , multicast : '239.5.5.5' //multicast ip address to send to and listen on
-    , port      : 5555        //udp port to send to and listen on
+    , port      : 5555        //udp port to send to
+    , bindingPort : 5556      //udp port to listen on. Default: port
     , reuseAddr : true        //boolean: allow multiple processes to bind to the
                               //         same address and port. Default: true
     , loopback  : true        //boolean: whether or not to receive sent datagrams
@@ -46,7 +47,8 @@ var udp = require('datagram-stream');
 var stream = udp({
     address     : '0.0.0.0'         //address to bind to
     , broadcast : '255.255.255.255' //broadcast ip address to send to
-    , port      : 5555              //udp port to send to and listen on
+    , port      : 5555              //udp port to send to
+    , bindingPort : 5556            //udp port to listen on. Default: port
     , reuseAddr : true              //boolean: allow multiple processes to bind to the
                                     //         same address and port. Default: true
  });
@@ -66,7 +68,8 @@ var udp = require('datagram-stream');
 var stream = udp({
     address     : '0.0.0.0'   //address to bind to
     , unicast   : '127.0.0.1' //unicast ip address to send to
-    , port      : 5555        //udp port to send to and listen on
+    , port      : 5555        //udp port to send to
+    , bindingPort : 5556      //udp port to listen on. Default: port
     , reuseAddr : true        //boolean: allow multiple processes to bind to the
                               //         same address and port. Default: true
  });

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ function UdpStream (options, cb) {
 
     var address         = options.address       || '0.0.0.0';
     var port            = options.port          || 12345;
+    var bindingPort     = options.bindingPort   || port;
     var unicast         = options.unicast       || null;
     var broadcast       = options.broadcast     || null;
     var multicast       = options.multicast     || null;
@@ -61,7 +62,7 @@ function UdpStream (options, cb) {
 
     socket.on('error', startupErrorListener);
 
-    socket.bind(port, address);
+    socket.bind(bindingPort, address);
 
     socket.on('listening', function () {
         socket.removeListener('error', startupErrorListener);


### PR DESCRIPTION
the binding port is not always the same as the one where packets are sent. For example if you start a client and a server on localhost, you need the client to listen on a different port than the server.
